### PR TITLE
Update Sync-SympaMailingList.ps1

### DIFF
--- a/Sync-SympaMailingList.ps1
+++ b/Sync-SympaMailingList.ps1
@@ -75,7 +75,7 @@ param(
         $ToDoList = Compare-Object -ReferenceObject $ReferenceArray -DifferenceObject $ResultsArray -Property MailingList, Member
 
         if($ToDoList.Count -eq "0"){
-            Write-Host "Nothing to do"
+            Write-Verbose "Nothing to do"
         }
 
         #Perform Add/Remove


### PR DESCRIPTION
A minor change, but for constancy, the type of output from the sync command should be the same (verbose) when there is "Nothing to do" as it is when Add-SympaMailingListMember and Remove-SympaMailingListMember are called.